### PR TITLE
Block Registry

### DIFF
--- a/src/main/java/com/crypticmushroom/planetbound/PBCore.java
+++ b/src/main/java/com/crypticmushroom/planetbound/PBCore.java
@@ -62,7 +62,7 @@ public class PBCore
         PBItems.init();
 
         PBLogDev.printInfo("Preparing blocks for registry...");
-        PBBlocks.init();
+        /* FIXME: Wait, what happens here now? */
 
         PBLogDev.printInfo("Initializing biomes...");
         PBBiomes.init();

--- a/src/main/java/com/crypticmushroom/planetbound/blocks/PBGrass.java
+++ b/src/main/java/com/crypticmushroom/planetbound/blocks/PBGrass.java
@@ -28,22 +28,23 @@ import net.minecraftforge.fml.relauncher.SideOnly;
  */
 public class PBGrass extends Block implements PBBlockTinted
 {
+    protected Block dirtBlock;
+    private final Planet[] planets_found_on;
 
-    protected PBDirt dirtBlock;
-
-    public PBGrass(PBDirt dirtBlock)
+    public PBGrass(Block dirtBlock)
     {
         this(dirtBlock, Material.GRASS, Material.GRASS.getMaterialMapColor());
     }
 
-    public PBGrass(PBDirt dirtBlock, MapColor mapColorIn)
+    public PBGrass(Block dirtBlock, MapColor mapColorIn)
     {
         this(dirtBlock, Material.GRASS, mapColorIn);
     }
 
-    public PBGrass(PBDirt dirtBlock, Material materialIn, MapColor mapColorIn)
+    public PBGrass(Block dirtBlock, Material materialIn, MapColor mapColorIn, Planet... planets)
     {
         super(materialIn, mapColorIn);
+        this.planets_found_on = planets;
         this.setSoundType(SoundType.PLANT);
         this.setHardness(0.9F);
         this.setTickRandomly(true);
@@ -55,7 +56,7 @@ public class PBGrass extends Block implements PBBlockTinted
     @Override
     public Planet[] getPlanets()
     {
-        return dirtBlock.getPlanets();
+        return planets_found_on.clone();
     }
 
     @Override

--- a/src/main/java/com/crypticmushroom/planetbound/blocks/PBLeaves.java
+++ b/src/main/java/com/crypticmushroom/planetbound/blocks/PBLeaves.java
@@ -6,42 +6,48 @@ import java.util.Random;
 import com.crypticmushroom.planetbound.world.planet.Planet;
 import com.google.common.collect.Lists;
 
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockLeaves;
 import net.minecraft.block.BlockPlanks;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.BlockRenderLayer;
+import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class PBLeaves extends BlockLeaves implements PBBlockTinted
 {
 
     private final Planet[] planets_found_on;
-    protected final PBSapling sapling;
+    protected final Block sapling;
     protected final Item appleDrop;
     protected MapColor mapColor;
 
-    public PBLeaves(PBSapling sapling, Planet... planets)
+    public PBLeaves(Block sapling, Planet... planets)
     {
         this(sapling, null, Material.LEAVES.getMaterialMapColor(), planets);
     }
 
-    public PBLeaves(PBSapling sapling, Item appleDrop, Planet... planets)
+    public PBLeaves(Block sapling, Item appleDrop, Planet... planets)
     {
         this(sapling, appleDrop, Material.LEAVES.getMaterialMapColor(), planets);
     }
 
-    public PBLeaves(PBSapling sapling, MapColor mapColorIn, Planet... planets)
+    public PBLeaves(Block sapling, MapColor mapColorIn, Planet... planets)
     {
         this(sapling, null, mapColorIn, planets);
     }
 
-    public PBLeaves(PBSapling sapling, Item appleDrop, MapColor mapColorIn, Planet... planets)
+    public PBLeaves(Block sapling, Item appleDrop, MapColor mapColorIn, Planet... planets)
     {
         this.planets_found_on = planets;
         this.sapling = sapling;
@@ -124,5 +130,19 @@ public class PBLeaves extends BlockLeaves implements PBBlockTinted
     public MapColor getMapColor(IBlockState state, IBlockAccess worldIn, BlockPos pos)
     {
         return mapColor;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    @Deprecated
+    public boolean shouldSideBeRendered(IBlockState state, IBlockAccess world, BlockPos pos, EnumFacing side)
+    {
+        return Blocks.LEAVES.shouldSideBeRendered(state, world, pos, side);
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public BlockRenderLayer getBlockLayer() {
+        return Blocks.LEAVES.getBlockLayer();
     }
 }

--- a/src/main/java/com/crypticmushroom/planetbound/blocks/PBLeaves.java
+++ b/src/main/java/com/crypticmushroom/planetbound/blocks/PBLeaves.java
@@ -142,7 +142,15 @@ public class PBLeaves extends BlockLeaves implements PBBlockTinted
 
     @Override
     @SideOnly(Side.CLIENT)
-    public BlockRenderLayer getBlockLayer() {
+    public BlockRenderLayer getBlockLayer()
+    {
         return Blocks.LEAVES.getBlockLayer();
+    }
+
+    @Override
+    @Deprecated
+    public boolean isOpaqueCube(IBlockState state)
+    {
+        return Blocks.LEAVES.isOpaqueCube(state);
     }
 }

--- a/src/main/java/com/crypticmushroom/planetbound/blocks/PBPlanks.java
+++ b/src/main/java/com/crypticmushroom/planetbound/blocks/PBPlanks.java
@@ -1,0 +1,36 @@
+package com.crypticmushroom.planetbound.blocks;
+
+import com.crypticmushroom.planetbound.world.planet.Planet;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.MapColor;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+
+public class PBPlanks extends Block implements PBBlock
+{
+    private Planet[] planets_found_on;
+    private MapColor mapColor;
+
+    public PBPlanks(MapColor color, Planet... planets)
+    {
+        super(Material.WOOD);
+        planets_found_on = planets;
+        mapColor = color;
+        this.setHardness(2.0f);
+    }
+
+    @Override
+    public Planet[] getPlanets()
+    {
+        return planets_found_on.clone();
+    }
+
+    @Override
+    @Deprecated
+    public MapColor getMapColor(IBlockState state, IBlockAccess worldIn, BlockPos pos)
+    {
+        return mapColor;
+    }
+}

--- a/src/main/java/com/crypticmushroom/planetbound/blocks/PBStone.java
+++ b/src/main/java/com/crypticmushroom/planetbound/blocks/PBStone.java
@@ -1,0 +1,37 @@
+package com.crypticmushroom.planetbound.blocks;
+
+import com.crypticmushroom.planetbound.world.planet.Planet;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.MapColor;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IBlockAccess;
+
+public class PBStone extends Block implements PBBlock
+{
+    private Planet[] planets_found_on;
+    private MapColor mapColor;
+
+    public PBStone(MapColor color, Planet... planets)
+    {
+        super(Material.ROCK);
+        planets_found_on = planets;
+        mapColor = color;
+        this.setHardness(2.0f);
+        this.setResistance(5.0F);
+    }
+
+    @Override
+    public Planet[] getPlanets()
+    {
+        return planets_found_on.clone();
+    }
+
+    @Override
+    @Deprecated
+    public MapColor getMapColor(IBlockState state, IBlockAccess worldIn, BlockPos pos)
+    {
+        return mapColor;
+    }
+}

--- a/src/main/java/com/crypticmushroom/planetbound/client/ClientEventHandler.java
+++ b/src/main/java/com/crypticmushroom/planetbound/client/ClientEventHandler.java
@@ -1,14 +1,10 @@
 package com.crypticmushroom.planetbound.client;
 
-import java.util.List;
-
 import com.crypticmushroom.planetbound.PBCore;
 import com.crypticmushroom.planetbound.networking.PBGuiHandler;
 import com.crypticmushroom.planetbound.networking.PBNetworkHandler;
 import com.crypticmushroom.planetbound.networking.packet.PBPacketOpenContainer;
-import com.google.common.collect.Lists;
 
-import net.minecraft.block.BlockLeaves;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainerCreative;
 import net.minecraft.entity.player.EntityPlayer;
@@ -17,7 +13,6 @@ import net.minecraftforge.client.event.TextureStitchEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.InputEvent;
-import net.minecraftforge.fml.common.gameevent.TickEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -25,16 +20,6 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 @EventBusSubscriber(modid = PBCore.MOD_ID, value = Side.CLIENT)
 public class ClientEventHandler
 {
-
-    public static List<BlockLeaves> LEAF_BLOX = Lists.newArrayList();
-
-    @SubscribeEvent
-    public static void onTick(TickEvent event)
-    {
-        for (BlockLeaves leaves : LEAF_BLOX)
-            leaves.setGraphicsLevel(Minecraft.getMinecraft().gameSettings.fancyGraphics);
-    }
-
     @SubscribeEvent
     public static void keyPressed(InputEvent.KeyInputEvent event)
     {

--- a/src/main/java/com/crypticmushroom/planetbound/init/PBBlocks.java
+++ b/src/main/java/com/crypticmushroom/planetbound/init/PBBlocks.java
@@ -1,7 +1,5 @@
 package com.crypticmushroom.planetbound.init;
 
-import static com.crypticmushroom.planetbound.init.PBCreativeTabs.TAB_BLOCKS;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -9,10 +7,11 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import com.crypticmushroom.planetbound.blocks.*;
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraftforge.fml.common.registry.GameRegistry;
 import org.apache.commons.lang3.Validate;
 
 import com.crypticmushroom.planetbound.PBCore;
-import com.crypticmushroom.planetbound.client.ClientEventHandler;
 import com.crypticmushroom.planetbound.logger.PBLogDev;
 import com.crypticmushroom.planetbound.world.biome.PBBiomeColorHelper;
 import com.crypticmushroom.planetbound.world.gen.PBAmberwoodTreeGen;
@@ -21,8 +20,6 @@ import com.crypticmushroom.planetbound.world.planet.Planet;
 import com.google.common.collect.Maps;
 
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockLeaves;
-import net.minecraft.block.SoundType;
 import net.minecraft.block.material.MapColor;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
@@ -33,11 +30,9 @@ import net.minecraft.client.renderer.color.BlockColors;
 import net.minecraft.client.renderer.color.IBlockColor;
 import net.minecraft.client.renderer.color.IItemColor;
 import net.minecraft.client.renderer.color.ItemColors;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.ColorizerFoliage;
 import net.minecraft.world.ColorizerGrass;
@@ -50,123 +45,65 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import static com.crypticmushroom.planetbound.init.PBCreativeTabs.TAB_BLOCKS;
+
 @EventBusSubscriber(modid = PBCore.MOD_ID)
+@GameRegistry.ObjectHolder(PBCore.MOD_ID)
 public class PBBlocks
 {
     private static final List<Block> blocks = new ArrayList<>();
 
     // Kybrite
-    public static PBOre kybrite_ore;
-    public static PBOre kybrite_ore_ronnian;
-    public static PBStorageBlock kybrite_block;
+    public static final Block kybrite_ore = registerBlock(new PBOre(), "kybrite_ore");
+    public static final Block kybrite_ore_ronnian = registerBlock(new PBOre(PBPlanets.RONNE), "kybrite_ore_ronnian");
+    public static final Block kybrite_block = registerBlock(new PBStorageBlock(MapColor.BLACK), "kybrite_block");
     // Verdanite
-    public static PBOre verdanite_ore;
-    public static PBOre verdanite_ore_ronnian;
-    public static PBStorageBlock verdanite_block;
+    public static final Block verdanite_ore = registerBlock(new PBOre(), "verdanite_ore");
+    public static final Block verdanite_ore_ronnian = registerBlock(new PBOre(PBPlanets.RONNE), "verdanite_ore_ronnian");
+    public static final Block verdanite_block = registerBlock(new PBStorageBlock(/* TODO maybe add custom map color for this block */MapColor.LIME), "verdanite_block");
     // Rendium
-    public static PBOre rendium_ore;
-    public static PBOre rendium_ore_ronnian;
-    public static PBStorageBlock rendium_block;
+    public static final Block rendium_ore = registerBlock(new RendiumOre(), "rendium_ore");
+    public static final Block rendium_ore_ronnian = registerBlock(new RendiumOre(PBPlanets.RONNE), "rendium_ore_ronnian");
+    public static final Block rendium_block = registerBlock(new PBStorageBlock(MapColor.YELLOW), "rendium_block");
     // Other
-    public static Block inventors_forge;
-    public static Block lit_inventors_forge;
-    public static PBStorageBlock fortium_block;
-    public static Block rift;
-    public static Puffball puffball_block;
+    public static final Block inventors_forge = registerBlock(new InventorsForge(false), "inventors_forge");
+    public static final Block lit_inventors_forge = registerBlock(new InventorsForge(true), "lit_inventors_forge", null, false);
+    public static final Block fortium_block = registerBlock(new PBStorageBlock(MapColor.GREEN_STAINED_HARDENED_CLAY), "fortium_block");
+    public static final Block rift = registerBlock(new Rift(Blocks.IRON_BLOCK), "rift", null, false);
+    public static final Block puffball_block = registerBlock(new Puffball(Material.WOOD, MapColor.BLUE,/* TODO add small puffball */ Item.getItemFromBlock(Blocks.BROWN_MUSHROOM)), "blue_puffball_block");
     // Ronnian Blocks
-    public static PBSand ronnian_sand;
-    public static Block ronnian_sandstone;
-    public static Block ronnian_stone;
-    public static Block ronnian_stone_smooth;
-    public static Block ronnian_stone_chiseled;
-    public static Block ronnian_sandstone_chiseled;
-    public static Block ronnian_sandstone_smooth;
-    public static PBDirt ronnian_dirt;
-    public static PBDirt ronnian_coarse_dirt;
-    public static PBGrass ronnian_grass;
-    public static PBTallgrass ronnian_tallgrass;
+    public static final Block ronnian_sand = registerBlock(new PBSand(MapColor.RED, PBPlanets.RONNE), "scarlet_sand");
+    public static final Block ronnian_sandstone = registerBlock(new PBStone(MapColor.RED, PBPlanets.RONNE), "ronnian_sandstone");
+    public static final Block ronnian_sandstone_smooth = registerBlock(new PBStone(MapColor.RED, PBPlanets.RONNE), "ronnian_sandstone_smooth");
+    public static final Block ronnian_sandstone_chiseled = registerBlock(new PBStone(MapColor.RED, PBPlanets.RONNE), "ronnian_sandstone_chiseled");
+    public static final Block ronnian_stone = registerBlock(new PBStone(MapColor.GRAY, PBPlanets.RONNE), "ronnian_stone");
+    public static final Block ronnian_stone_smooth = registerBlock(new PBStone(MapColor.GRAY, PBPlanets.RONNE), "ronnian_stone_smooth");
+    public static final Block ronnian_stone_chiseled = registerBlock(new PBStone(MapColor.GRAY, PBPlanets.RONNE), "ronnian_stone_chiseled");
+    public static final Block ronnian_dirt = registerBlock(new PBDirt(MapColor.RED_STAINED_HARDENED_CLAY, PBPlanets.RONNE), "ronnian_dirt");
+    public static final Block ronnian_coarse_dirt = registerBlock(new PBDirt(MapColor.RED, PBPlanets.RONNE), "ronnian_coarse_dirt");
+    public static final Block ronnian_grass = registerBlock(new PBGrass(ronnian_dirt, MapColor.RED_STAINED_HARDENED_CLAY), "ronnian_grass");
+    public static final Block ronnian_tallgrass = registerBlock(new PBTallgrass(MapColor.RED_STAINED_HARDENED_CLAY, PBPlanets.RONNE), "ronnian_tallgrass");
     // Halkir
-    public static PBOre halkir_ore;
-    public static PBStorageBlock halkir_block;
+    public static final Block halkir_ore = registerBlock(new PBOre(), "halkir_ore");
+    public static final Block halkir_block = registerBlock(new PBStorageBlock(MapColor.GRAY), "halkir_block");
     // Bloodstone
-    public static PBOre bloodstone_ore;
-    public static PBStorageBlock bloodstone_block;
+    public static final Block bloodstone_ore = registerBlock(new BloodstoneOre(PBPlanets.RONNE), "bloodstone_ore");
+    public static final Block bloodstone_block = registerBlock(new PBStorageBlock(MapColor.RED, PBPlanets.RONNE), "bloodstone_block");
     // Emberwood
-    public static PBSapling emberwood_sapling;
-    public static PBLeaves emberwood_leaves;
-    public static Block emberwood_planks;
-    public static Block emberwood;
-    public static Block emberwood_crafting_table;
+    public static final Block emberwood_sapling = registerBlock(new PBSapling(new PBEmberwoodTreeGen(true), PBPlanets.RONNE), "emberwood_sapling");
+    public static final Block emberwood_leaves = registerBlock(new PBLeaves(emberwood_sapling, MapColor.RED, PBPlanets.RONNE), "emberwood_leaves");
+    public static final Block emberwood_planks = registerBlock(new PBPlanks(MapColor.ORANGE_STAINED_HARDENED_CLAY, PBPlanets.RONNE), "emberwood_planks");
+    public static final Block emberwood = registerBlock(new PBLog(PBPlanets.RONNE), "emberwood_log");
+    public static final Block emberwood_crafting_table = registerBlock(new PBWorkbench(PBPlanets.RONNE), "emberwood_crafting_table");
     // Amberwood
-    public static PBSapling amberwood_sapling;
-    public static PBLeaves amberwood_leaves;
-    public static Block amberwood_planks;
-    public static Block amberwood;
+    public static final Block amberwood_sapling = registerBlock(new PBSapling(new PBAmberwoodTreeGen(true), PBPlanets.RONNE), "amberwood_sapling");
+    public static final Block amberwood_leaves = registerBlock(new PBLeaves(amberwood_sapling, MapColor.RED, PBPlanets.RONNE), "amberwood_leaves");
+    public static final Block amberwood_planks = registerBlock(new PBPlanks(MapColor.YELLOW_STAINED_HARDENED_CLAY, PBPlanets.RONNE), "amberwood_planks");
+    public static final Block amberwood = registerBlock(new PBLog(PBPlanets.RONNE), "amberwood_log");
 
-    public static void init()
-    {
-        // Kybrite
-        kybrite_ore = registerBlock(new PBOre(), "kybrite_ore");
-        kybrite_block = registerBlock(new PBStorageBlock(MapColor.BLACK), "kybrite_block");
-        // Verdanite
-        verdanite_ore = registerBlock(new PBOre(), "verdanite_ore");
-        verdanite_block = registerBlock(
-                new PBStorageBlock(/* TODO maybe add custom map color for this block */MapColor.LIME),
-                "verdanite_block");
-        // Rendium
-        rendium_ore = registerBlock(new RendiumOre(), "rendium_ore");
-        rendium_block = registerBlock(new PBStorageBlock(MapColor.YELLOW), "rendium_block");
-        // Other
-        inventors_forge = registerBlock(new InventorsForge(false), "inventors_forge");
-        lit_inventors_forge = registerBlock(new InventorsForge(true), "lit_inventors_forge", (CreativeTabs) null, false);
-        fortium_block = registerBlock(new PBStorageBlock(MapColor.GREEN_STAINED_HARDENED_CLAY), "fortium_block");
-        rift = registerBlock(new Rift(Blocks.IRON_BLOCK), "rift", (CreativeTabs) null, false);
-        puffball_block = (Puffball) registerBlock(new Puffball(Material.WOOD, MapColor.BLUE,
-                        /* TODO add small puffball */ Item.getItemFromBlock(Blocks.BROWN_MUSHROOM)),
-                "blue_puffball_block").setUnlocalizedName("puffball");
-        // Ronnian Blocks
-        ronnian_sand = registerBlock(new PBSand(MapColor.RED, PBPlanets.RONNE), "scarlet_sand");
-        ronnian_sandstone = registerBlock(createStone(PBPlanets.RONNE), "ronnian_sandstone");
-        ronnian_stone = registerBlock(createStone(PBPlanets.RONNE), "ronnian_stone");
-        ronnian_stone_smooth = registerBlock(createStone(PBPlanets.RONNE), "ronnian_stone_smooth");
-        ronnian_stone_chiseled = registerBlock(createStone(PBPlanets.RONNE), "ronnian_stone_chiseled");
-        ronnian_sandstone_chiseled = registerBlock(createStone(PBPlanets.RONNE), "ronnian_sandstone_chiseled");
-        ronnian_sandstone_smooth = registerBlock(createStone(PBPlanets.RONNE), "ronnian_sandstone_smooth");
-        ronnian_dirt = registerBlock(new PBDirt(MapColor.RED_STAINED_HARDENED_CLAY, PBPlanets.RONNE), "ronnian_dirt");
-        ronnian_coarse_dirt = registerBlock(new PBDirt(MapColor.RED, PBPlanets.RONNE),
-                "ronnian_coarse_dirt");
-        ronnian_grass = registerBlock(new PBGrass(ronnian_dirt, MapColor.RED_STAINED_HARDENED_CLAY), "ronnian_grass");
-        ronnian_tallgrass = registerBlock(new PBTallgrass(MapColor.RED_STAINED_HARDENED_CLAY, PBPlanets.RONNE), "ronnian_tallgrass");
-        halkir_ore = registerBlock(new PBOre(), "halkir_ore");
-        halkir_block = registerBlock(new PBStorageBlock(MapColor.GRAY), "halkir_block");
-        bloodstone_ore = registerBlock(new BloodstoneOre(PBPlanets.RONNE), "bloodstone_ore");
-        bloodstone_block = registerBlock(new PBStorageBlock(MapColor.RED, PBPlanets.RONNE), "bloodstone_block");
-        verdanite_ore_ronnian = registerBlock(new PBOre(PBPlanets.RONNE), "verdanite_ore_ronnian");
-        kybrite_ore_ronnian = registerBlock(new PBOre(PBPlanets.RONNE), "kybrite_ore_ronnian");
-        rendium_ore_ronnian = registerBlock(new RendiumOre(PBPlanets.RONNE), "rendium_ore_ronnian");
-        // Emberwood
-        emberwood_sapling = registerBlock(new PBSapling(new PBEmberwoodTreeGen(true), PBPlanets.RONNE), "emberwood_sapling");
-        emberwood_leaves = registerBlock(new PBLeaves(emberwood_sapling, MapColor.RED, PBPlanets.RONNE), "emberwood_leaves");
-        emberwood_planks = registerBlock(createPlanks(PBPlanets.RONNE), "emberwood_planks");
-        emberwood = registerBlock(new PBLog(PBPlanets.RONNE), "emberwood_log");
-        emberwood_crafting_table = registerBlock(new PBWorkbench(PBPlanets.RONNE), "emberwood_crafting_table");
-        // Amberwood
-        amberwood_sapling = registerBlock(new PBSapling(new PBAmberwoodTreeGen(true), PBPlanets.RONNE), "amberwood_sapling");
-        amberwood_leaves = registerBlock(new PBLeaves(amberwood_sapling, MapColor.RED, PBPlanets.RONNE), "amberwood_leaves");
-        amberwood_planks = registerBlock(createPlanks(PBPlanets.RONNE), "amberwood_planks");
-        amberwood = registerBlock(new PBLog(PBPlanets.RONNE), "amberwood_log");
-    }
-
-    private static PBBlockBasic createStone(Planet... planetsIn)
-    {
-        return (PBBlockBasic) new PBBlockBasic(Material.ROCK, planetsIn).setHardness(2.0f);
-    }
-
-    private static PBBlockBasic createPlanks(Planet... planetsIn)
-    {
-        return (PBBlockBasic) new PBBlockBasic(Material.WOOD).setSoundType(SoundType.WOOD).setHardness(2.0F)
-                .setResistance(5.0F);
-    }
+    /*
+    * Everything below here is additional registry for other block purposes
+    */
 
     public static void setupColors()
     {
@@ -211,17 +148,10 @@ public class PBBlocks
             }
         }
 
-        final IItemColor itemColor = new IItemColor()
-        {
-
-            @Override
-            public int colorMultiplier(ItemStack stack, int tintIndex)
-            {
-                IBlockState iblockstate = ((ItemBlock) stack.getItem()).getBlock()
-                        .getStateFromMeta(stack.getMetadata());
-                return bc.colorMultiplier(iblockstate, (IBlockAccess) null, (BlockPos) null, tintIndex);
-            }
-
+        final IItemColor itemColor = (stack, tintIndex) -> {
+            IBlockState iblockstate = ((ItemBlock) stack.getItem()).getBlock()
+                    .getStateFromMeta(stack.getMetadata());
+            return bc.colorMultiplier(iblockstate, (IBlockAccess) null, (BlockPos) null, tintIndex);
         };
 
         Map<Planet, IBlockColor> definedGrassColors = Maps.newHashMap(),
@@ -300,11 +230,6 @@ public class PBBlocks
         block.setRegistryName(PBCore.MOD_ID, name);
 
         blocks.add(block);
-
-        if (block instanceof BlockLeaves)
-        {
-            ClientEventHandler.LEAF_BLOX.add((BlockLeaves) block);
-        }
 
         if (registerItem)
             PBItems.registerItem(new ItemBlock(block), name, (CreativeTabs) null);


### PR DESCRIPTION
This is here for review.

Basically, the block registry has some... changes made to it.
In-depth, some other slightly smaller changes have been made

1. No more `createStone` or `createPlanks`. It'd just be easier to inherit from a block class. Though, maybe something will need to be done for the Sandstone blocks due to them being less resistant than Stone (comparing with Vanilla).
2. Registering Blocks no longer needs `PBBlocks.init()`. Instead, everything is shown to be done without needing to call the method.
3. Pertaining to point 2, there is no `init()` class. Everything is annotated with a `@ObjectHolder` and `@EventBusSubscriber`.
4. Some block calls have been changed to just refer to `Block`. However, a full test on these changes will need to be noted. At present, nothing bad has happened, however, the Grass block will need to be checked for biome tinting.
5. Changed how Leaves are rendered based on Graphic Setting. Not sure why it was checking every tick, sounds somewhat ineffective, especially when there are methods for that.
6. This is minor, but `IItemColor` has been changed to use a lambda. This was picked up by Intellij and was able to convert itself, though needs to be checked if anything else has happened.

Any observations, note it here or in the Discord server.